### PR TITLE
Improve Docker build workflow with caching and multi-platform support

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Docker Build
+name: Build and Push Docker Image
 
 on:
   workflow_dispatch:
@@ -9,31 +9,30 @@ on:
       - 'Dockerfile'
       - 'go.*'
       - '**/*.go'
+      - '.dockerignore'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [amd64, arm64]
     permissions:
       contents: read
       packages: write
 
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
+          registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -41,20 +40,15 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
-          platforms: linux/${{ matrix.platform }}
           push: true
-          tags: ghcr.io/${{ github.repository }}:latest
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
 
-  cleanup:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    steps:
-      - name: Clean up GHCR images
-        uses: dataaxiom/ghcr-cleanup-action@v1
+      - name: Delete untagged images from GitHub Container Registry
+        uses: actions/delete-package-versions@v5
         with:
-          delete-untagged: true
-        env:
-          GHCR_TOKEN: ${{ secrets.GHCR_PAT }}
+          package-name: ${{ github.event.repository.name }}
+          package-type: 'container'
+          min-versions-to-keep: 2


### PR DESCRIPTION
## Summary

- Consolidate multi-platform builds from matrix strategy into single Buildx job for simplified workflow
- Add GitHub Actions cache support (`cache-from`/`cache-to`) to significantly speed up subsequent builds
- Remove redundant QEMU setup step (Buildx handles cross-platform builds automatically)
- Move cleanup logic from separate job into main build job for better efficiency
- Introduce environment variables for registry and image name to improve maintainability
- Update workflow name to be more descriptive

## Test plan

- [ ] Verify workflow runs successfully on push to main
- [ ] Confirm both amd64 and arm64 images are built and pushed to GHCR
- [ ] Validate that cache is properly utilized in subsequent builds
- [ ] Check that old untagged images are cleaned up correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)